### PR TITLE
feat(remote_config): download artwork remote config

### DIFF
--- a/app/configs/postcard/postcard_configs.json
+++ b/app/configs/postcard/postcard_configs.json
@@ -27,6 +27,7 @@
     "wait_confirmed_to_send": false
   },
   "feralfile_artwork_action": {
-    "allow_download_artwork_contracts": ["KT19VkuK7tw22m4P36xRpPiMT4qzEw8YAN8A"]
+    "allow_download_artwork_contracts": ["KT19VkuK7tw22m4P36xRpPiMT4qzEw8YAN8A"],
+    "sound_piece_contract_addresses": ["0x19da6876a149fE5a40c3496A21DBBeFdc9A3a636"]
   }
 }

--- a/app/configs/postcard/postcard_configs.json
+++ b/app/configs/postcard/postcard_configs.json
@@ -25,5 +25,8 @@
   },
   "postcard_action": {
     "wait_confirmed_to_send": false
+  },
+  "feralfile_artwork_action": {
+    "allow_download_artwork_contracts": ["KT19VkuK7tw22m4P36xRpPiMT4qzEw8YAN8A"]
   }
 }

--- a/app/configs/postcard/postcard_configs.json
+++ b/app/configs/postcard/postcard_configs.json
@@ -2,7 +2,8 @@
   "merchandise": {
     "enable": false,
     "allow_view_only": true,
-    "must_complete": true
+    "must_complete": true,
+    "postcard_tokenId_regex": "^.*$"
   },
   "pay_to_mint": {
     "enable": true,


### PR DESCRIPTION
[add link to download memento into App](https://github.com/bitmark-inc/feral-file/issues/1994)